### PR TITLE
Added expand button for sample images

### DIFF
--- a/views/home.ejs
+++ b/views/home.ejs
@@ -45,6 +45,7 @@
                     <h1>Horse</h1>
                     <p>Photograph of an astronaut riding a horse.</p>
                     <button class="btn" aria-label="Download" onclick="downloadImage('expImg1')"> Download</button>
+<button class="btn" aria-label="Expand" onclick="openModal('1.webp')">Expand</button>
                   </div>
                 </div>
                 <div class="cardEx float-in" style="border-radius: 2rem;">
@@ -53,6 +54,7 @@
                     <h1>Capybara</h1>
                     <p>An oil painting of a capybara wearing a crown.</p>
                     <button class="btn" aria-label="Download" onclick="downloadImage('expImg2')">Download</button>
+<button class="btn" aria-label="Expand" onclick="openModal('2.webp')">Expand</button>
                   </div>
                 </div>
                 <div class="cardEx float-in" style="border-radius: 2rem;">
@@ -61,6 +63,7 @@
                     <h1>Sports Car</h1>
                     <p>Synthwave sports car on a port road.</p>
                     <button class="btn"  aria-label="Download" onclick="downloadImage('expImg3')"> Download </button>
+<button class="btn" aria-label="Expand" onclick="openModal('3.webp')">Expand</button>
                   </div>
                 </div>
                 <div class="cardEx float-in" style="border-radius: 2rem;">
@@ -69,6 +72,7 @@
                     <h1>Astronaut</h1>
                     <p>An astronaut lounging in a resort in space, vaporwave.</p>
                     <button class="btn" aria-label="Download" onclick="downloadImage('expImg4')"> Download</button>
+<button class="btn" aria-label="Expand" onclick="openModal('4.webp')">Expand</button>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
**Added expand button for AI-generated sample images**


 **Description** 

I added an expand button to the section displaying sample images made by AI. This change enhances user interaction by allowing users to view larger versions of the images, making it easier to appreciate the details and quality of the AI-generated content. 

**How It Works:**
- Viewing Images: Click the expand button next to any sample image to view a larger version.
- Improved Clarity: This feature allows you to appreciate the details and quality of the AI-generated content more easily.
**Usage**:
- Navigate to the AI sample images section of the application.
- Click on the expand button for any image to see it in a larger format.

## Fixes #1217

## Screenshots
BEFORE
![image](https://github.com/user-attachments/assets/9adc0f1f-9af6-4ea2-bb7a-770e771a96bd)
AFTER : 
![image](https://github.com/user-attachments/assets/b2428d26-a036-461e-867e-ca640cc54b65)
![image](https://github.com/user-attachments/assets/e048bac3-58d2-41c6-84d3-532a91f721f8)


## Checklist

- [X] Tests have been added or updated to cover the changes
- [X] Documentation has been updated to reflect the changes
- [X] Code follows the established coding style guidelines
- [X] All tests are passing


Is your feature request related to a problem? Please describe.
The example images can only be downloaded. I want to closely examine the details of example images but am unable to view them in an expanded or full-screen mode. The current image display is small and limits the user's ability to see finer details clearly.

Describe the solution you'd like
I would like to contribute to adding an expanded view option for example images. Users should be able to click on an image to enlarge it, either in full screen or in a larger modal window. Additionally, a zoom feature would enhance the clarity of detailed parts of the image.

Describe alternatives you've considered
An alternative solution could be a hover-to-zoom feature, where users can hover their cursor over a portion of the image to see it in more detail without needing to open a full-screen view.

Additional context
image

If change acceptable kindly merge and assign me this PR and add labels : hacktoberfest-accepted, gssoc-ext, any level label suitable

